### PR TITLE
Update dependencies bump akka 2.6, drop scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
   - 2.12.10
   - 2.13.1
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 script:
   - if [[ $TRAVIS_SCALA_VERSION =~ ^2\.13.* ]]; then
       sbt ++$TRAVIS_SCALA_VERSION clean test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ scala:
   - 2.12.10
   - 2.13.1
 jdk:
-  - oraclejdk9
+  - openjdk8
 script:
   - if [[ $TRAVIS_SCALA_VERSION =~ ^2\.13.* ]]; then
       sbt ++$TRAVIS_SCALA_VERSION clean test;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ sudo: false
 
 language: scala
 scala:
-  - 2.11.12
-  - 2.12.8
-  - 2.13.0
+  - 2.12.10
+  - 2.13.1
 jdk:
   - oraclejdk8
 script:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small library for those who use [akka-testkit](http://doc.akka.io/docs/akka/cu
 
 ## Usage
 
-To use akka-testkit-specs2 in an existing SBT project with Scala 2.11, 2.12 or 2.13, add the following dependency to your `build.sbt`:
+To use akka-testkit-specs2 in an existing SBT project with Scala 2.12 or 2.13, add the following dependency to your `build.sbt`:
 
 ```scala
 libraryDependencies += "net.ruippeixotog" %% "akka-testkit-specs2" % "0.2.3"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= Seq(
   "org.specs2"            %% "specs2-core"        % "4.5.1",
-  "com.typesafe.akka"     %% "akka-testkit"       % "2.5.23")
+  "com.typesafe.akka"     %% "akka-testkit"       % "2.6.1")
 
 scalariformPreferences := scalariformPreferences.value
   .setPreference(DanglingCloseParenthesis, Prevent)

--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ import scalariform.formatter.preferences._
 name := "akka-testkit-specs2"
 organization := "net.ruippeixotog"
 
-scalaVersion := "2.13.0"
-crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
+scalaVersion := "2.13.1"
+crossScalaVersions := Seq("2.12.10", "2.13.1")
 
 resolvers ++= Seq(
   Resolver.bintrayRepo("scalaz", "releases"))


### PR DESCRIPTION
This adds a support for the latest version of Akka. 

Since Akka 2.6 drops support for Scala 2.11, I dropped it as well in this PR.

I updated Scala versions to latests as well.

Tests pass for both Scala 2.12 and 2.13