### PR TITLE
Fix `receive.allOf` scaladoc

### DIFF
--- a/core/src/main/scala/net/ruippeixotog/akka/testkit/specs2/api/package.scala
+++ b/core/src/main/scala/net/ruippeixotog/akka/testkit/specs2/api/package.scala
@@ -58,11 +58,11 @@ package object api {
     def like[R: AsResult](f: PartialFunction[A, R]): SkippableReceiveMatcher[P, A]
 
     /**
-     * Checks that the probe received a sequence of messages in order. The timeout is applied to the whole sequence and
-     * not per message (i.e. all the messages have to be received before the timeout duration).
+     * Checks that the probe received a sequence of messages, possibly unordered. The timeout is applied to
+     * the whole sequence and not per message (i.e. all the messages have to be received before the timeout duration).
      *
      * @param msgs the expected sequence of messages
-     * @return a new matcher that expects a probe to have received all the messages in `msgs` in order.
+     * @return a new matcher that expects a probe to have received all the messages in `msgs`, possibly unordered.
      */
     def allOf(msgs: A*): SkippableReceiveMatcher[P, Seq[A]]
 


### PR DESCRIPTION
It stated the order of the received messages was checked when it is not.

Confirmed this in the spec and readme (and implementation 😛)
https://github.com/ruippeixotog/akka-testkit-specs2/blob/7220a219154b6ce12a8122245870e68f58979ff7/classic/src/test/scala/net/ruippeixotog/akka/testkit/specs2/AkkaMatchersSpec.scala#L89-L113

https://github.com/ruippeixotog/akka-testkit-specs2/blob/7220a219154b6ce12a8122245870e68f58979ff7/README.md#L57-L59